### PR TITLE
wip on multiPXD files support

### DIFF
--- a/PXDConverter/MarshalService.cs
+++ b/PXDConverter/MarshalService.cs
@@ -3,27 +3,94 @@ using System.Runtime.InteropServices;
 
 namespace PXDConverter
 {
-    //try-catch clauses are overused cause we don't know what exceptions may occur in external eJ_Tool.dll methods
-    public static class MarshalService
+    interface PXDDecompressLibrary
     {
+        void InitializeDll();
+        void Decompress(string pxdPath, int leftOffset, int leftSize, int rightOffset, int rightSize, int sampleRate, string outputPath);
+        void CloseDll();
+    }
+
+    //try-catch clauses are overused cause we don't know what exceptions may occur in external pxd32d5_d4.dll methods
+    public class PXD32Library : PXDDecompressLibrary
+    {
+        [DllImport("pxd32d5_d4.dll", EntryPoint = "PInit", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
+        private static extern int Initialize();
 
         //Integer parameters are not known, hence the names. They probably function as buffer offsets etc.
-        //To use our paths with external ADecompress function, we need to marshal them as char*. String, StringBuilder, char[], byte[] won't work.
-        [DllImport("eJ_Tool.dll", EntryPoint = "ADecompress", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        private static extern int ADecompress([MarshalAs(UnmanagedType.LPStr)]string pxdPath, int offset, int b, int c, int d, int e, [MarshalAs(UnmanagedType.LPStr)]string tmpPath, int f, int g);
+        //To use our paths with external RWavToTemp function, we need to marshal them as char*. String, StringBuilder, char[], byte[] won't work.
+        [DllImport("pxd32d5_d4.dll", EntryPoint = "RWavToTemp", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
+        private static extern int WavToTemp([MarshalAs(UnmanagedType.LPStr)] string pxdPath, [MarshalAs(UnmanagedType.LPStr)] string tmpPath, int a, int b, int c, int d, int f);
 
+        [DllImport("pxd32d5_d4.dll", EntryPoint = "PClose", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
+        private static extern int Close();
 
-        public static void ConvertWavToRawDataBuffer(string wavPath, string bufferTmpPath)
+        public void InitializeDll()
+        {
+            Console.WriteLine("Initializing pxd32d5_d4.dll");
+
+            try
+            {
+                Initialize();
+            }
+            catch
+            {
+                Console.WriteLine("Couldn't find or initialize pxd32d5_d4.dll. Be sure to locate it in the same location as Converter exe file.");
+                Environment.Exit(-2);
+            }
+        }
+
+        public void CloseDll()
+        {
+            Console.WriteLine("Closing .dll file...");
+
+            try
+            {
+                Close();
+            }
+            catch
+            {
+                Console.WriteLine("Couldn't close the pxd32d5_d4.dll!");
+                Environment.Exit(-5);
+            }
+        }
+
+        public void Decompress(string pxdPath, int leftOffset, int leftSize, int rightOffset, int rightSize, int sampleRate, string outputPath)
         {
             try
             {
-                ADecompress(wavPath, 0, 0x0001E9AD, 0, 0, 0x00049D40, bufferTmpPath, 1, 0x0AAD0000);
+                WavToTemp(pxdPath, outputPath, 0, 0, 0, 0, 0);
             }
             catch
             {
                 Console.WriteLine("Error during creating temporary buffer file via using external eJay dll method. Are you sure that PXD file is valid?");
+                Environment.Exit(-3);
+            }
+        }
+    }
+
+    public class EjToolLibrary : PXDDecompressLibrary
+    {
+
+        [DllImport("eJ_Tool.dll", EntryPoint = "ADecompress", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
+        private static extern int ADecompress([MarshalAs(UnmanagedType.LPStr)] string pxdPath, int leftOffset, int leftSize, int rightOffset, int rightLenght, int sampleRate, [MarshalAs(UnmanagedType.LPStr)] string tmpPath);
+
+
+        public void InitializeDll() { }
+
+        public void Decompress(string pxdPath, int leftOffset, int leftSize, int rightOffset, int rightSize, int sampleRate, string outputPath)
+        {
+
+            try
+            {
+                ADecompress(pxdPath, leftOffset, leftSize, rightOffset, rightSize, sampleRate, outputPath);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Error during creating temporary buffer file via using external eJay dll method. Are you sure that PXD file is valid? Detailed message: {e.Message}");
                 Environment.Exit(-4);
             }
         }
+
+        public void CloseDll() { }
     }
 }

--- a/PXDConverter/MarshalService.cs
+++ b/PXDConverter/MarshalService.cs
@@ -3,15 +3,9 @@ using System.Runtime.InteropServices;
 
 namespace PXDConverter
 {
-    interface PXDDecompressLibrary
-    {
-        void InitializeDll();
-        void Decompress(string pxdPath, int leftOffset, int leftSize, int rightOffset, int rightSize, int sampleRate, string outputPath);
-        void CloseDll();
-    }
 
     //try-catch clauses are overused cause we don't know what exceptions may occur in external pxd32d5_d4.dll methods
-    public class PXD32Library : PXDDecompressLibrary
+    public class PXD32Library
     {
         [DllImport("pxd32d5_d4.dll", EntryPoint = "PInit", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         private static extern int Initialize();
@@ -54,7 +48,7 @@ namespace PXDConverter
             }
         }
 
-        public void Decompress(string pxdPath, int leftOffset, int leftSize, int rightOffset, int rightSize, int sampleRate, string outputPath)
+        public void Decompress(string pxdPath, string outputPath)
         {
             try
             {
@@ -68,7 +62,7 @@ namespace PXDConverter
         }
     }
 
-    public class EjToolLibrary : PXDDecompressLibrary
+    public class EjToolLibrary
     {
 
         [DllImport("eJ_Tool.dll", EntryPoint = "ADecompress", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]

--- a/PXDConverter/MarshalService.cs
+++ b/PXDConverter/MarshalService.cs
@@ -1,57 +1,23 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace PXDConverter
 {
-    //try-catch clauses are overused cause we don't know what exceptions may occur in external pxd32d5_d4.dll methods
+    //try-catch clauses are overused cause we don't know what exceptions may occur in external eJ_Tool.dll methods
     public static class MarshalService
     {
-        [DllImport("pxd32d5_d4.dll", EntryPoint = "PInit", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        private static extern int Initialize();
 
         //Integer parameters are not known, hence the names. They probably function as buffer offsets etc.
-        //To use our paths with external RWavToTemp function, we need to marshal them as char*. String, StringBuilder, char[], byte[] won't work.
-        [DllImport("pxd32d5_d4.dll", EntryPoint = "RWavToTemp", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        private static extern int WavToTemp([MarshalAs(UnmanagedType.LPStr)]string pxdPath, [MarshalAs(UnmanagedType.LPStr)]string tmpPath, int a, int b, int c, int d, int f);
+        //To use our paths with external ADecompress function, we need to marshal them as char*. String, StringBuilder, char[], byte[] won't work.
+        [DllImport("eJ_Tool.dll", EntryPoint = "ADecompress", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
+        private static extern int ADecompress([MarshalAs(UnmanagedType.LPStr)]string pxdPath, int offset, int b, int c, int d, int e, [MarshalAs(UnmanagedType.LPStr)]string tmpPath, int f, int g);
 
-        [DllImport("pxd32d5_d4.dll", EntryPoint = "PClose", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        private static extern int Close();
-
-        public static void InitializeDll()
-        {
-            Console.WriteLine("Initializing pxd32d5_d4.dll");
-            
-            try
-            {
-                Initialize();
-            }
-            catch
-            {
-                Console.WriteLine("Couldn't find or initialize pxd32d5_d4.dll. Be sure to locate it in the same location as Converter exe file.");
-                Environment.Exit(-2);
-            }
-        }
-
-        public static void CloseDll()
-        {
-            Console.WriteLine("Closing .dll file...");
-            
-            try
-            {
-                Close();
-            }
-            catch
-            {
-                Console.WriteLine("Couldn't close the pxd32d5_d4.dll!");
-                Environment.Exit(-3);
-            }
-        }
 
         public static void ConvertWavToRawDataBuffer(string wavPath, string bufferTmpPath)
         {
             try
             {
-                WavToTemp(wavPath, bufferTmpPath, 0, 0, 0, 0, 0);
+                ADecompress(wavPath, 0, 0x0001E9AD, 0, 0, 0x00049D40, bufferTmpPath, 1, 0x0AAD0000);
             }
             catch
             {

--- a/PXDConverter/Program.cs
+++ b/PXDConverter/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime;
@@ -8,8 +8,78 @@ using System.Text;
 
 namespace PXDConverter
 {
+    // thanks to https://stackoverflow.com/a/42440257/699934
+    internal static class StreamReaderExtensions
+    {
+        public static IEnumerable<string> ReadUntil(this StreamReader reader, string delimiter)
+        {
+            List<char> buffer = new List<char>();
+            CircularBuffer<char> delim_buffer = new CircularBuffer<char>(delimiter.Length);
+            while (reader.Peek() >= 0)
+            {
+                char c = (char)reader.Read();
+                delim_buffer.Enqueue(c);
+                if (delim_buffer.ToString() == delimiter || reader.EndOfStream)
+                {
+                    if (buffer.Count > 0)
+                    {
+                        if (!reader.EndOfStream)
+                        {
+                            buffer.Add(c);
+                            yield return new String(buffer.ToArray()).Substring(0, buffer.Count - delimiter.Length);
+                        }
+                        else
+                        {
+                            buffer.Add(c);
+                            if (delim_buffer.ToString() != delimiter)
+                                yield return new String(buffer.ToArray());
+                            else
+                                yield return new String(buffer.ToArray()).Substring(0, buffer.Count - delimiter.Length);
+                        }
+                        buffer.Clear();
+                    }
+                    continue;
+                }
+                buffer.Add(c);
+            }
+        }
+
+        private class CircularBuffer<T> : Queue<T>
+        {
+            private int _capacity;
+
+            public CircularBuffer(int capacity)
+                : base(capacity)
+            {
+                _capacity = capacity;
+            }
+
+            new public void Enqueue(T item)
+            {
+                if (base.Count == _capacity)
+                {
+                    base.Dequeue();
+                }
+                base.Enqueue(item);
+            }
+
+            public override string ToString()
+            {
+                List<String> items = new List<string>();
+                foreach (var x in this)
+                {
+                    items.Add(x.ToString());
+                };
+                return String.Join("", items);
+            }
+        }
+    }
     public static class Program
     {
+
+        private static string PxdHeader = "tPxD";
+        
+        private static char[] PxdHeaderAsArray = "tPxD".ToCharArray();
         private static void Main(string[] args)
         {
             Console.ForegroundColor = ConsoleColor.Blue;
@@ -17,9 +87,9 @@ namespace PXDConverter
             Console.WriteLine("|--' _X_ |__>   |___ [__] | \\|  \\/  |=== |--<  |  |=== |--<");
             Console.WriteLine();
             Console.ResetColor();
-            
-            
-            if(args.Length < 1)
+
+
+            if (args.Length < 1)
             {
                 Console.WriteLine(
                     "You at least need 1 argument to run this program: PXD file path.\nIf you wish to convert multiple files at once, please " +
@@ -28,83 +98,133 @@ namespace PXDConverter
                 Console.WriteLine();
                 Console.WriteLine("USAGE: ");
                 Console.WriteLine();
-                
+
                 Console.WriteLine("PXDConverter.exe <pxd_file_location>");
                 Console.WriteLine("PXDConverter.exe -all <folder_location>\n" +
                                   "Note: If <folder_location> won't be specified, program will try to use the path where program " +
                                   "was executed.");
-                
+
                 Environment.Exit(-1);
             }
-            
+
             MarshalService.InitializeDll();
 
             var argPath = string.Empty;
             bool recursiveSearch = false;
-            
+
             if (args[0].Equals("-all"))
             {
                 recursiveSearch = true;
-                
+
                 if (args.Length == 2)
                 {
-                    argPath = args[2];
+                    argPath = args[1];
                 }
             }
             else
             {
                 argPath = args[0];
-                
-                if(!argPath.Contains(".pxd", StringComparison.OrdinalIgnoreCase))
+
+                if (!argPath.Contains(".pxd", StringComparison.OrdinalIgnoreCase))
                 {
                     argPath += ".pxd";
                 }
             }
 
             Directory.CreateDirectory("converted_wav_files");
-            
+
             //buffer used by .dll
-            var tmpPath = Directory.GetCurrentDirectory() + "\\converted_wav_files\\tmp_f.tmp";
+            var tmpPath = Path.GetTempPath() + "\\pxd_converter.tmp";
+            if (!Directory.Exists(tmpPath))
+            {
+                Directory.CreateDirectory(tmpPath);
+            }
 
             if (recursiveSearch)
-                ConvertMultipleFiles(argPath, tmpPath);
+                ConvertMultipleFiles(argPath);
             else
-                ConvertOneFile(argPath, tmpPath);
+                ConvertOneFile(argPath);
 
             MarshalService.CloseDll();
-            
+
+            // for debug: Directory.Delete(tmpPath, true);
+
             Console.WriteLine("Finished.");
         }
 
-        private static void ConvertOneFile(string argPath, string tmpPath)
+        private static List<string> ConvertMultiPXDFile(string argPath)
         {
+            List<string> extractedPaths = new List<string>();
+            using (System.IO.StreamReader sr = new System.IO.StreamReader(argPath))
+            {
+                int fileNumber = 0;
+                // todo: read filename from the header
+                // todo: make processing parallel
+                foreach (var pxd in sr.ReadUntil(PxdHeader).AsParallel())
+                {
+                    if (pxd.Length > 0) {
+                        string filePath = $"{Path.GetTempPath()}pxd_converter.tmp\\{Path.GetFileName(argPath)}-{++fileNumber}.pxd";
+                        extractedPaths.Add(filePath);
+                        Console.WriteLine($"Extract {fileNumber} part to file: {filePath}");
+                        using (System.IO.StreamWriter sw = new System.IO.StreamWriter(filePath))
+                        {
+                            sw.WriteLine(PxdHeader + pxd);
+                        }
+                        // for debug: ConvertOneFile(filePath);
+                    }
+                }
+            }
+
+            return extractedPaths;
+        }
+
+        private static bool IsPXDFile(string argPath)
+        {
+            List<string> extractedPaths = new List<string>();
+            using (System.IO.StreamReader sr = new System.IO.StreamReader(argPath))
+            {
+                if (!sr.EndOfStream)
+                {
+                    char[] buffer = new char[4];
+                    sr.ReadBlock(buffer);
+                    return buffer.SequenceEqual(PxdHeaderAsArray);
+                }
+            }
+
+            return false;
+        }
+
+        private static void ConvertOneFile(string argPath)
+        {
+            Console.WriteLine($"Converting raw data file {argPath} to wav format...");
+
+            string tmpPath = $"{Path.GetTempPath()}pxd_converter.tmp\\temp.wav";
+
             MarshalService.ConvertWavToRawDataBuffer(argPath, tmpPath);
-            
-            Console.WriteLine("Converting raw data to wav format...");
 
             RawToWav(argPath, tmpPath);
         }
 
-        private static void ConvertMultipleFiles(string argPath, string tmpPath)
+        private static void ConvertMultipleFiles(string argPath)
         {
             Console.WriteLine("Searching for all .pxd files in specified location...");
 
             if (string.IsNullOrEmpty(argPath))
                 argPath = Directory.GetCurrentDirectory();
-            
-            string[] filePaths = Directory.GetFiles(argPath, "*.pxd", SearchOption.AllDirectories);
 
-            if (filePaths.Length == 0)
+            List<string> filePaths = Directory.GetFiles(argPath, "*.*", SearchOption.AllDirectories).ToList().FindAll(path => IsPXDFile(path));
+
+            if (filePaths.Count == 0)
             {
                 Console.WriteLine("Couldn't find any .pxd file!");
                 return;
             }
-            
+
             foreach (var path in filePaths)
             {
                 Console.WriteLine("Found file: " + path);
-
-                ConvertOneFile(path, tmpPath);
+                ConvertMultiPXDFile(path);
+                // ConvertOneFile was here
             }
         }
 
@@ -112,28 +232,32 @@ namespace PXDConverter
         {
             var path = Directory.GetCurrentDirectory() + "\\converted_wav_files\\";
             var name = Path.GetFileName(pxdPath);
-            
+
             var wavPath = path + name.Remove(name.Length - 3) + "wav";
+            Console.WriteLine("Wav file path: " + wavPath);
             FileStream wavStream = null;
             BinaryWriter wavWriter = null;
-            
+
             try
             {
-                wavStream = new FileStream(wavPath, FileMode.Create);
-                wavWriter = new BinaryWriter(wavStream);
-                int length = (int) new FileInfo(tmpPath).Length;
+                int length = (int)new FileInfo(tmpPath).Length;
+                if (length == 0) {
+                    throw new Exception("raw wav file is empty, looks like file convertation was failed");
+                }
                 int riffSize = length + 0x24;
 
+                wavStream = new FileStream(wavPath, FileMode.Create);
+                wavWriter = new BinaryWriter(wavStream);
                 wavWriter.Write(Encoding.ASCII.GetBytes("RIFF"));
                 wavWriter.Write(riffSize);
                 wavWriter.Write(Encoding.ASCII.GetBytes("WAVEfmt "));
                 wavWriter.Write(16);
-                wavWriter.Write((short) 1); // Encoding: PCM
-                wavWriter.Write((short) 1); // Channels: MONO
+                wavWriter.Write((short)1); // Encoding: PCM
+                wavWriter.Write((short)1); // Channels: MONO
                 wavWriter.Write(44100); // Sample rate: 44100
                 wavWriter.Write(88200); // Average bytes per second
-                wavWriter.Write((short) 2); // Block align
-                wavWriter.Write((short) 16); // Bits per sample
+                wavWriter.Write((short)2); // Block align
+                wavWriter.Write((short)16); // Bits per sample
                 wavWriter.Write(Encoding.ASCII.GetBytes("data"));
                 wavWriter.Write(length);
 
@@ -144,16 +268,17 @@ namespace PXDConverter
                 wavStream.Close();
                 wavWriter.Close();
             }
-            catch
+            catch (Exception e)
             {
+                Console.WriteLine(e.ToString());
                 wavStream?.Close();
                 wavWriter?.Close();
                 Console.WriteLine("Couldn't convert raw data to wav. Perhaps .wav provided path is invalid?");
-                File.Delete(wavPath);
+                //File.Delete(wavPath);
             }
             finally
             {
-                File.Delete(tmpPath);
+                //File.Delete(tmpPath);
             }
         }
 

--- a/PXDConverter/Program.cs
+++ b/PXDConverter/Program.cs
@@ -107,8 +107,6 @@ namespace PXDConverter
                 Environment.Exit(-1);
             }
 
-            MarshalService.InitializeDll();
-
             var argPath = string.Empty;
             bool recursiveSearch = false;
 
@@ -144,8 +142,6 @@ namespace PXDConverter
                 ConvertMultipleFiles(argPath);
             else
                 ConvertOneFile(argPath);
-
-            MarshalService.CloseDll();
 
             // for debug: Directory.Delete(tmpPath, true);
 

--- a/PXDConverter/Program.cs
+++ b/PXDConverter/Program.cs
@@ -228,7 +228,7 @@ namespace PXDConverter
                 if (part.Length > 0 && records.Count > 0 && record.offset == 0)
                 {
                     // switch to B binary file
-                    part = "b";
+                    part = (part[0] + 1).ToString();
                 }
                 records.Add((record, header));
             }
@@ -242,6 +242,10 @@ namespace PXDConverter
             if (File.Exists($"{Path.GetDirectoryName(descriptorPath)}\\{binFilePrefix}a"))
             {
                 part = "a";
+            }
+            else if (File.Exists($"{Path.GetDirectoryName(descriptorPath)}\\{binFilePrefix}A"))
+            {
+                part = "A";
             }
             else if (File.Exists($"{Path.GetDirectoryName(descriptorPath)}\\{binFilePrefix}"))
             {
@@ -277,14 +281,21 @@ namespace PXDConverter
                 if (part.Length > 0 && files > 0 && record.offset == 0)
                 {
                     // switch to B binary file
-                    part = "b";
+                    part = ((char)(part[0] + 1)).ToString();
                 }
                 string dir;
 
-                if (header.package.Length == 0 && header.type.Length == 0)
+                if (header.package.Length == 0 || header.package == "eJay Musicdirector")
                 {
-                    // use descriptor filename and a type number
-                    dir = $"converted_wav_files\\{binFilePrefix}\\{record.type}";
+                    // use descriptor filename
+                    if (header.type.Length == 0)
+                    {
+                        dir = $"converted_wav_files\\{binFilePrefix}\\{record.type}";
+                    }
+                    else
+                    {
+                        dir = $"converted_wav_files\\{binFilePrefix}\\{header.type}";
+                    }
                 }
                 else
                 {
@@ -340,7 +351,7 @@ namespace PXDConverter
                 if (part.Length > 0 && records.Count > 0 && record.offset == 0)
                 {
                     // switch to B binary file
-                    part = "b";
+                    part = ((char)(part[0] + 1)).ToString();
                 }
                 records.Add((record, header));
             }

--- a/PXDConverter/Program.cs
+++ b/PXDConverter/Program.cs
@@ -553,7 +553,7 @@ namespace PXDConverter
         private static void SclToWav(string sclPath)
         {
             var path = "converted_wav_files";
-            string wavPath = $"{path}\\{Path.GetDirectoryName(Path.GetDirectoryName(sclPath))}\\{Path.GetFileName(Path.GetDirectoryName(sclPath))}";
+            string wavPath = $"{path}\\{Path.GetFileName(Path.GetDirectoryName(Path.GetDirectoryName(sclPath)))}\\{Path.GetFileName(Path.GetDirectoryName(sclPath))}";
             string wavFullPath = $"{wavPath}\\{removeBadCharsFromFilename(Path.GetFileNameWithoutExtension(sclPath))}.wav";
             Debug.WriteLine(wavFullPath);
             if (!File.Exists(wavFullPath))

--- a/PXDConverter/Program.cs
+++ b/PXDConverter/Program.cs
@@ -8,78 +8,27 @@ using System.Text;
 
 namespace PXDConverter
 {
-    // thanks to https://stackoverflow.com/a/42440257/699934
-    internal static class StreamReaderExtensions
-    {
-        public static IEnumerable<string> ReadUntil(this StreamReader reader, string delimiter)
-        {
-            List<char> buffer = new List<char>();
-            CircularBuffer<char> delim_buffer = new CircularBuffer<char>(delimiter.Length);
-            while (reader.Peek() >= 0)
-            {
-                char c = (char)reader.Read();
-                delim_buffer.Enqueue(c);
-                if (delim_buffer.ToString() == delimiter || reader.EndOfStream)
-                {
-                    if (buffer.Count > 0)
-                    {
-                        if (!reader.EndOfStream)
-                        {
-                            buffer.Add(c);
-                            yield return new String(buffer.ToArray()).Substring(0, buffer.Count - delimiter.Length);
-                        }
-                        else
-                        {
-                            buffer.Add(c);
-                            if (delim_buffer.ToString() != delimiter)
-                                yield return new String(buffer.ToArray());
-                            else
-                                yield return new String(buffer.ToArray()).Substring(0, buffer.Count - delimiter.Length);
-                        }
-                        buffer.Clear();
-                    }
-                    continue;
-                }
-                buffer.Add(c);
-            }
-        }
-
-        private class CircularBuffer<T> : Queue<T>
-        {
-            private int _capacity;
-
-            public CircularBuffer(int capacity)
-                : base(capacity)
-            {
-                _capacity = capacity;
-            }
-
-            new public void Enqueue(T item)
-            {
-                if (base.Count == _capacity)
-                {
-                    base.Dequeue();
-                }
-                base.Enqueue(item);
-            }
-
-            public override string ToString()
-            {
-                List<String> items = new List<string>();
-                foreach (var x in this)
-                {
-                    items.Add(x.ToString());
-                };
-                return String.Join("", items);
-            }
-        }
-    }
     public static class Program
     {
 
         private static string PxdHeader = "tPxD";
-        
+
         private static char[] PxdHeaderAsArray = "tPxD".ToCharArray();
+        private static string TmpPath = Path.GetTempPath() + "\\pxd_converter.tmp\\";
+
+        enum SampleType
+        {
+            Beats,
+            Bass,
+            Keys,
+            Spheres,
+            Guitar,
+            Male,
+            Female,
+            Extra,
+            Fx
+        }
+
         private static void Main(string[] args)
         {
             Console.ForegroundColor = ConsoleColor.Blue;
@@ -122,159 +71,345 @@ namespace PXDConverter
             else
             {
                 argPath = args[0];
-
-                if (!argPath.Contains(".pxd", StringComparison.OrdinalIgnoreCase))
-                {
-                    argPath += ".pxd";
-                }
             }
 
             Directory.CreateDirectory("converted_wav_files");
 
             //buffer used by .dll
-            var tmpPath = Path.GetTempPath() + "\\pxd_converter.tmp";
-            if (!Directory.Exists(tmpPath))
+            if (!Directory.Exists(TmpPath))
             {
-                Directory.CreateDirectory(tmpPath);
+                Directory.CreateDirectory(TmpPath);
             }
 
             if (recursiveSearch)
-                ConvertMultipleFiles(argPath);
+                FindMultipleFiles(argPath);
             else
-                ConvertOneFile(argPath);
+            {
+                // todo check if it is header
+                var lib = new PXD32Library();
+                lib.InitializeDll();
+                ProcessSinglePXDFile(argPath, lib);
+                lib.CloseDll();
+            }
 
-            // for debug: Directory.Delete(tmpPath, true);
+            Directory.Delete(TmpPath, true);
 
             Console.WriteLine("Finished.");
         }
 
-        private static List<string> ConvertMultiPXDFile(string argPath)
-        {
-            List<string> extractedPaths = new List<string>();
-            using (System.IO.StreamReader sr = new System.IO.StreamReader(argPath))
-            {
-                int fileNumber = 0;
-                // todo: read filename from the header
-                // todo: make processing parallel
-                foreach (var pxd in sr.ReadUntil(PxdHeader).AsParallel())
-                {
-                    if (pxd.Length > 0) {
-                        string filePath = $"{Path.GetTempPath()}pxd_converter.tmp\\{Path.GetFileName(argPath)}-{++fileNumber}.pxd";
-                        extractedPaths.Add(filePath);
-                        Console.WriteLine($"Extract {fileNumber} part to file: {filePath}");
-                        using (System.IO.StreamWriter sw = new System.IO.StreamWriter(filePath))
-                        {
-                            sw.WriteLine(PxdHeader + pxd);
-                        }
-                        // for debug: ConvertOneFile(filePath);
-                    }
-                }
-            }
-
-            return extractedPaths;
-        }
-
-        private static bool IsPXDFile(string argPath)
-        {
-            List<string> extractedPaths = new List<string>();
-            using (System.IO.StreamReader sr = new System.IO.StreamReader(argPath))
-            {
-                if (!sr.EndOfStream)
-                {
-                    char[] buffer = new char[4];
-                    sr.ReadBlock(buffer);
-                    return buffer.SequenceEqual(PxdHeaderAsArray);
-                }
-            }
-
-            return false;
-        }
-
-        private static void ConvertOneFile(string argPath)
+        private static void ProcessSinglePXDFile(string argPath, PXD32Library lib)
         {
             Console.WriteLine($"Converting raw data file {argPath} to wav format...");
 
-            string tmpPath = $"{Path.GetTempPath()}pxd_converter.tmp\\temp.wav";
+            string tmpPath = TmpPath.ToString() + "tmp.wav";
 
-            MarshalService.ConvertWavToRawDataBuffer(argPath, tmpPath);
+            lib.Decompress(argPath, 0, 0, 0, 0, 0, tmpPath);
 
+            // todo rename file from pxd
             RawToWav(argPath, tmpPath);
         }
 
-        private static void ConvertMultipleFiles(string argPath)
+        private static (int, R) processBytes<R>(byte[] arr, int p, int size, Func<byte[], R> convert)
+        {
+            R res = convert(arr[p..(p + size)]);
+            return (p + size, res);
+        }
+
+
+        private static (int, byte[]) readBytes(byte[] arr, int p, int size)
+        {
+            return (p + size, arr[p..(p + size)]);
+        }
+
+        private static bool isLastRecord(byte[] descriptorBytes, int p)
+        {
+            p += 8;
+            (p, short sampleRateByte) = processBytes(descriptorBytes, p, 2, b => BitConverter.ToInt16(b));
+            return sampleRateByte == 0;
+        }
+
+        private record PXDRecord(int id, int group, string name, int offset, int lenght, int sampleRate, int type);
+
+        private static (int, PXDRecord) readBinaryPXDRecord(byte[] descriptorBytes, int p)
+        {
+            (p, byte[] fileSeparator) = readBytes(descriptorBytes, p, 2);
+            (p, byte id) = processBytes(descriptorBytes, p, 1, b => b[0]);
+            (p, byte group) = processBytes(descriptorBytes, p, 1, b => b[0]);
+            p += 2; // serarator
+            (p, short nameLenght) = processBytes(descriptorBytes, p, 2, b => BitConverter.ToInt16(b));
+            (p, string name) = processBytes(descriptorBytes, p, nameLenght, b => ASCIIEncoding.UTF8.GetString(b));
+            (p, short sampleRateByte) = processBytes(descriptorBytes, p, 2, b => BitConverter.ToInt16(b));
+            (p, short type) = processBytes(descriptorBytes, p, 2, b => BitConverter.ToInt16(b));
+            (p, int offset) = processBytes(descriptorBytes, p, 4, b => BitConverter.ToInt32(b));
+            (p, int lenght) = processBytes(descriptorBytes, p, 4, b => BitConverter.ToInt32(b));
+            p += 24; // some useless data for us
+            //Console.WriteLine($"[{group}:{id}] '{name}'[{nameLenght}] offset: {offset} lenght: {lenght} sampleRateByte: {sampleRateByte}, type2: {type}");
+            int sampleRate = sampleRateByte * 151200;
+            return (p, new PXDRecord(id, group, name, offset, lenght, sampleRate, type));
+        }
+
+        private static void ProcessMultiWithBinaryInf(string descriptorPath, EjToolLibrary lib)
+        {
+            Console.WriteLine($"Work with descriptor file '{descriptorPath}'");
+
+            string part = "";
+            if (File.Exists($"{Path.GetDirectoryName(descriptorPath)}\\{Path.GetFileNameWithoutExtension(descriptorPath)[..^3]}a"))
+            {
+                part = "a";
+            }
+            else if (File.Exists($"{Path.GetDirectoryName(descriptorPath)}\\{Path.GetFileNameWithoutExtension(descriptorPath)[..^3]}"))
+            {
+                part = "";
+            }
+            else
+            {
+                Console.WriteLine("This discriptor is not in directory with binary MultiPXD file");
+                return;
+            }
+
+            byte[] descriptorBytes = File.ReadAllBytes(descriptorPath);
+            int p = 8;
+            List<PXDRecord> records = new List<PXDRecord>();
+            while (!isLastRecord(descriptorBytes, p))
+            {
+                (p, PXDRecord record) = readBinaryPXDRecord(descriptorBytes, p);
+                records.Add(record);
+            }
+            int files = 0;
+            HashSet<int> types = new HashSet<int>();
+            for (int index = 0; index < records.Count; index++)
+            {
+                var item = records.ElementAt(index);
+                types.Add(item.type);
+                PXDRecord? stereo = null;
+                if (index + 1 < records.Count && (records.ElementAt(index + 1).name.Length == 0))
+                {
+                    stereo = records.ElementAt(index + 1);
+                    index++;
+                }
+                string filenameWithoutBadChars = string.Join("", item.name.Trim().Split(Path.GetInvalidFileNameChars()));
+                string binPath = $"{Path.GetDirectoryName(descriptorPath)}\\{Path.GetFileNameWithoutExtension(descriptorPath)[..^3]}{part}";
+                if (part.Length > 0 && files > 0 && (item.offset == 0 || (stereo?.offset ?? -1) == 0))
+                {
+                    // switch to B binary file
+                    part = "b";
+                }
+                string dir = $"{Directory.GetCurrentDirectory()}\\converted_wav_files\\{Path.GetFileNameWithoutExtension(descriptorPath)[..^3]}\\{item.type}";
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+                string outputFile = $"{dir}\\{filenameWithoutBadChars}.wav";
+                if (!File.Exists(outputFile))
+                {
+                    lib.Decompress(binPath, item.offset, item.lenght, stereo?.offset ?? 0, stereo?.lenght ?? 0, item.sampleRate * (stereo != null ? 2 : 1), outputFile);
+                    if (!File.Exists(outputFile))
+                    {
+                        Console.WriteLine($"Warning: '{outputFile}' is not exists after decompression.");
+                    }
+                }
+                files++;
+            }
+            Console.WriteLine($"Totat files extracted: {files}, types: {string.Join(",", types)}");
+        }
+
+
+        private static PXDRecord readTextPXDRecord(string[] descriptorLines, int p)
+        {
+            int id = Int32.Parse(descriptorLines[p]);
+            int group = Int32.Parse(descriptorLines[p + 1]);
+            string pxdFilename = descriptorLines[p + 2][1..^1]; // remove ""
+            int offset = Int32.Parse(descriptorLines[p + 3]);
+            int lenght = Int32.Parse(descriptorLines[p + 4]);
+            string nameLine1 = descriptorLines[p + 5][1..^1]; // remove ""
+            string nameLine2 = descriptorLines[p + 6][1..^1]; // remove ""
+            string name = nameLine1 + nameLine2;
+            int sampleRateByte = Int32.Parse(descriptorLines[p + 7]);
+            int type = Int32.Parse(descriptorLines[p + 8]);
+            //Console.WriteLine($"[{group}:{id}] '{name}' offset: {offset} lenght: {lenght} sampleRateByte: {sampleRateByte}, type2: {type}");
+            int sampleRate = sampleRateByte * 151200;
+            return new PXDRecord(id, group, name, offset, lenght, sampleRate, type);
+        }
+
+        private static void ProcessMultiWithTextInf(string descriptorPath, EjToolLibrary lib)
+        {
+            Console.WriteLine($"Work with descriptor file '{descriptorPath}'");
+
+
+            string part = "";
+            if (File.Exists($"{Path.GetDirectoryName(descriptorPath)}\\{Path.GetFileNameWithoutExtension(descriptorPath)}a"))
+            {
+                part = "a";
+            }
+            else if (File.Exists($"{Path.GetDirectoryName(descriptorPath)}\\{Path.GetFileNameWithoutExtension(descriptorPath)}"))
+            {
+                part = "";
+            }
+            else
+            {
+                Console.WriteLine("This discriptor is not in directory with binary MultiPXD file");
+                return;
+            }
+
+            string[] descriptorLines = File.ReadAllLines(descriptorPath);
+            List<PXDRecord> records = new List<PXDRecord>();
+            for (int i = 14; i < descriptorLines.Length; i += 12)
+            {
+                records.Add(readTextPXDRecord(descriptorLines, i));
+            }
+            // stereo data stored not in sequence
+            records.Sort((a, b) => a.id.CompareTo(b.id));
+            int files = 0;
+            HashSet<int> types = new HashSet<int>();
+            for (int index = 0; index < records.Count; index++)
+            {
+                var item = records.ElementAt(index);
+                types.Add(item.type);
+                PXDRecord? stereo = null;
+                if (index + 1 < records.Count && (records.ElementAt(index + 1).name.Length == 0 || records.ElementAt(index + 1).name == item.name[..^1] + 'R'))
+                {
+                    stereo = records.ElementAt(index + 1);
+                    index++;
+                }
+                string filenameWithoutBadChars = string.Join("", item.name.Split(Path.GetInvalidFileNameChars()));
+                if (stereo != null)
+                {
+                    // drop "L" for stereo files
+                    filenameWithoutBadChars = filenameWithoutBadChars[..^1];
+                }
+                string binPath = $"{Path.GetDirectoryName(descriptorPath)}\\{Path.GetFileNameWithoutExtension(descriptorPath)}{part}";
+                if (part.Length > 0 && files > 0 && (item.offset == 0 || (stereo?.offset ?? -1) == 0))
+                {
+                    // switch to B binary file
+                    part = "b";
+                }
+                string dir = $"{Directory.GetCurrentDirectory()}\\converted_wav_files\\{Path.GetFileNameWithoutExtension(descriptorPath)}\\{item.type}";
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+                string outputFile = $"{dir}\\{filenameWithoutBadChars}.wav";
+                if (!File.Exists(outputFile))
+                {
+                    lib.Decompress(binPath, item.offset, item.lenght, stereo?.offset ?? 0, stereo?.lenght ?? 0, item.sampleRate * (stereo != null ? 2 : 1), outputFile);
+                    if (!File.Exists(outputFile))
+                    {
+                        Console.WriteLine($"Warning: '{outputFile}' is not exists after decompression.");
+                    }
+                }
+                files++;
+            }
+            Console.WriteLine($"Totat files extracted: {files}, types: {string.Join(",", types)}");
+        }
+
+        private static void FindMultipleFiles(string argPath)
         {
             Console.WriteLine("Searching for all .pxd files in specified location...");
 
             if (string.IsNullOrEmpty(argPath))
                 argPath = Directory.GetCurrentDirectory();
 
-            List<string> filePaths = Directory.GetFiles(argPath, "*.*", SearchOption.AllDirectories).ToList().FindAll(path => IsPXDFile(path));
+            string[] pxdFilesPaths = Directory.GetFiles(argPath, "*.pxd", SearchOption.AllDirectories);
+            string[] pxdFilesHeaderMultiWithTextInfPaths = Directory.GetFiles(argPath, "*0.inf", SearchOption.AllDirectories);
+            string[] pxdFilesHeaderMultiWithBinaryInfPaths = Directory.GetFiles(argPath, "*inf.bin", SearchOption.AllDirectories);
 
-            if (filePaths.Count == 0)
+            if (pxdFilesPaths.Length == 0 && pxdFilesHeaderMultiWithTextInfPaths.Length == 0 && pxdFilesHeaderMultiWithBinaryInfPaths.Length == 0)
             {
-                Console.WriteLine("Couldn't find any .pxd file!");
+                Console.WriteLine("Couldn't find anything to decompress!");
                 return;
             }
 
-            foreach (var path in filePaths)
+            if (pxdFilesPaths.Length > 0)
             {
-                Console.WriteLine("Found file: " + path);
-                ConvertMultiPXDFile(path);
-                // ConvertOneFile was here
+                var pxd32lib = new PXD32Library();
+                pxd32lib.InitializeDll();
+                foreach (var path in pxdFilesPaths)
+                {
+                    Console.WriteLine($"Process PXD file: {path}");
+                    ProcessSinglePXDFile(path, pxd32lib);
+                }
+                pxd32lib.CloseDll();
+            }
+
+            if (pxdFilesHeaderMultiWithTextInfPaths.Length > 0 || pxdFilesHeaderMultiWithBinaryInfPaths.Length > 0)
+            {
+                var lib = new EjToolLibrary();
+
+                if (pxdFilesHeaderMultiWithBinaryInfPaths.Length > 0)
+                {
+                    foreach (var path in pxdFilesHeaderMultiWithBinaryInfPaths)
+                    {
+                        Console.WriteLine($"Process MultiPXD header file (binary): {path}");
+                        ProcessMultiWithBinaryInf(path, lib);
+                    }
+                }
+
+                if (pxdFilesHeaderMultiWithTextInfPaths.Length > 0)
+                {
+                    foreach (var path in pxdFilesHeaderMultiWithTextInfPaths)
+                    {
+                        Console.WriteLine($"Process MultiPXD header file (text): {path}");
+                        ProcessMultiWithTextInf(path, lib);
+                    }
+                }
             }
         }
 
         private static void RawToWav(string pxdPath, string tmpPath)
         {
             var path = Directory.GetCurrentDirectory() + "\\converted_wav_files\\";
-            var name = Path.GetFileName(pxdPath);
+            var name = Path.GetFileNameWithoutExtension(pxdPath);
 
-            var wavPath = path + name.Remove(name.Length - 3) + "wav";
-            Console.WriteLine("Wav file path: " + wavPath);
-            FileStream wavStream = null;
-            BinaryWriter wavWriter = null;
-
-            try
+            var wavPath = path + name + ".wav";
+            if (!File.Exists(wavPath))
             {
-                int length = (int)new FileInfo(tmpPath).Length;
-                if (length == 0) {
-                    throw new Exception("raw wav file is empty, looks like file convertation was failed");
-                }
-                int riffSize = length + 0x24;
+                Console.WriteLine("Wav file path: " + wavPath);
+                FileStream? wavStream = null;
+                BinaryWriter? wavWriter = null;
 
-                wavStream = new FileStream(wavPath, FileMode.Create);
-                wavWriter = new BinaryWriter(wavStream);
-                wavWriter.Write(Encoding.ASCII.GetBytes("RIFF"));
-                wavWriter.Write(riffSize);
-                wavWriter.Write(Encoding.ASCII.GetBytes("WAVEfmt "));
-                wavWriter.Write(16);
-                wavWriter.Write((short)1); // Encoding: PCM
-                wavWriter.Write((short)1); // Channels: MONO
-                wavWriter.Write(44100); // Sample rate: 44100
-                wavWriter.Write(88200); // Average bytes per second
-                wavWriter.Write((short)2); // Block align
-                wavWriter.Write((short)16); // Bits per sample
-                wavWriter.Write(Encoding.ASCII.GetBytes("data"));
-                wavWriter.Write(length);
-
-                using (var fs = File.OpenRead(tmpPath))
+                try
                 {
-                    CopyStream(fs, wavStream);
+                    int length = (int)new FileInfo(tmpPath).Length;
+                    if (length == 0)
+                    {
+                        throw new Exception("raw wav file is empty, looks like file convertation was failed");
+                    }
+                    int riffSize = length + 0x24;
+
+                    wavStream = new FileStream(wavPath, FileMode.Create);
+                    wavWriter = new BinaryWriter(wavStream);
+                    wavWriter.Write(Encoding.ASCII.GetBytes("RIFF"));
+                    wavWriter.Write(riffSize);
+                    wavWriter.Write(Encoding.ASCII.GetBytes("WAVEfmt "));
+                    wavWriter.Write(16);
+                    wavWriter.Write((short)1); // Encoding: PCM
+                    wavWriter.Write((short)1); // Channels: MONO
+                    wavWriter.Write(44100); // Sample rate: 44100
+                    wavWriter.Write(88200); // Average bytes per second
+                    wavWriter.Write((short)2); // Block align
+                    wavWriter.Write((short)16); // Bits per sample
+                    wavWriter.Write(Encoding.ASCII.GetBytes("data"));
+                    wavWriter.Write(length);
+
+                    using (var fs = File.OpenRead(tmpPath))
+                    {
+                        CopyStream(fs, wavStream);
+                    }
+                    wavStream.Close();
+                    wavWriter.Close();
                 }
-                wavStream.Close();
-                wavWriter.Close();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.ToString());
-                wavStream?.Close();
-                wavWriter?.Close();
-                Console.WriteLine("Couldn't convert raw data to wav. Perhaps .wav provided path is invalid?");
-                //File.Delete(wavPath);
-            }
-            finally
-            {
-                //File.Delete(tmpPath);
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.ToString());
+                    wavStream?.Close();
+                    wavWriter?.Close();
+                    Console.WriteLine("Couldn't convert raw data to wav. Perhaps .wav provided path is invalid?");
+                    File.Delete(wavPath);
+                }
+                finally
+                {
+                    File.Delete(tmpPath);
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Small console application used for converting PXD files (eJay music files) to WA
 ## How does it work?
 Converter calls pxd32d5_d4.dll external methods used for unpacking PXD to raw binary data (stored in a temporary file). The new WAV file is created with appropriate values (see  [WAVE PCM format specification](http://soundfile.sapp.org/doc/WaveFormat) ), then raw binary data is copied from .tmp file.
 ## Usage:
-Application uses .NET 4.8. It also uses pxd32d5_d4.dll which needs to be located in the same folder as compiled .exe. You can find .dll file inside of your eJay installation directories.
+Application uses .NET 4.8. It also uses pxd32d5_d4.dll (old single .pxd files) and eJ_Tool.dll (for MultiPXD packages) which needs to be located in the same folder as compiled .exe. You can find .dll file inside of your eJay installation directories.
 Compile with MSBuild.exe or Visual Studio.
 
 If you want to convert only one file, run compiled program with one argument as follows:


### PR DESCRIPTION
It should resolve #3

I have done successfully splitting large PXD files into many smaller ones, but the function from .dll cannot successfully convert them to WAV. When comparing, old PXDs in different files and these PXDs from one big one have differences and may require different function parameters or approaches when unpacking.